### PR TITLE
Hydro

### DIFF
--- a/range_sensor_layer/include/range_sensor_layer/range_sensor_layer.h
+++ b/range_sensor_layer/include/range_sensor_layer/range_sensor_layer.h
@@ -30,7 +30,7 @@ private:
   double sensor_model(double r, double phi, double theta);
 
   void get_deltas(double angle, double *dx, double *dy);
-  void update_cell(double ox, double oy, double ot, double r, double nx, double ny);
+  void update_cell(double ox, double oy, double ot, double r, double nx, double ny, bool clear);
 
   double to_prob(unsigned char c){ return double(c)/costmap_2d::LETHAL_OBSTACLE; }
   unsigned char to_cost(double p){ return (unsigned char)(p*costmap_2d::LETHAL_OBSTACLE); }
@@ -39,6 +39,7 @@ private:
   std::string global_frame_;
 
   double clear_threshold_, mark_threshold_;
+  bool clear_on_max_reading_;
 
   double no_readings_timeout_;
   ros::Time last_reading_time_;

--- a/range_sensor_layer/src/range_sensor_layer.cpp
+++ b/range_sensor_layer/src/range_sensor_layer.cpp
@@ -141,7 +141,10 @@ void RangeSensorLayer::incomingRange(const sensor_msgs::RangeConstPtr& range)
   if (r < range->min_range)
     return;
   else if (r > range->max_range && clear_on_max_reading_)
+  {
     clear_sensor_cone = true;
+    r = range->max_range;
+  }
 
   max_angle_ = range->field_of_view/2;
 


### PR DESCRIPTION
Hi David,

We got the range_sensor_layer working pretty quickly this afternoon, but I ran across a behavior that was unexpected.  Our range sensors put out a range value > max_range when no obstacle is detected.  Intuitively, I expected this to clear the occupied cells up to max_range at least, but instead it just ignored these readings.  The result was a lot of ghost occupied cells in open space.  This pull request is a fix for that.  I made it a configuration parameter (boolean clear_on_max_reading, default false) so that by default it works as you programmed it, but now it also works much better for our case too.  I think it could be a useful addition to the layer.

It basically works by checking if the incoming range message is above the max_range, and if so, tell the update cell command for each update to replace the sensor_model probability with 0, out to max_range.

All in all, this is a great addition that solves a problem we have long had.  Thank you for the effort.
