### PR TITLE
Buffering and fixed distance support

### DIFF
--- a/range_sensor_layer/src/range_sensor_layer.cpp
+++ b/range_sensor_layer/src/range_sensor_layer.cpp
@@ -1,4 +1,5 @@
-#include<range_sensor_layer/range_sensor_layer.h>
+#include <range_sensor_layer/range_sensor_layer.h>
+#include <boost/algorithm/string.hpp>
 #include <pluginlib/class_list_macros.h>
 #include <angles/angles.h>
 
@@ -42,6 +43,24 @@ void RangeSensorLayer::onInitialize()
 
   nh.param("clear_on_max_reading", clear_on_max_reading_, false);
 
+  InputSensorType input_sensor_type = ALL;
+  std::string sensor_type_name;
+  nh.param("input_sensor_type", sensor_type_name, std::string("ALL"));
+
+  boost::to_upper(sensor_type_name);
+  ROS_INFO("%s: %s as input_sensor_type given", name_.c_str(), sensor_type_name.c_str());
+
+  if (sensor_type_name == "VARIABLE")
+    input_sensor_type = VARIABLE;
+  else if (sensor_type_name == "FIXED")
+    input_sensor_type = FIXED;
+  else if (sensor_type_name == "ALL")
+    input_sensor_type = ALL;
+  else
+  {
+    ROS_ERROR("%s: Invalid input sensor type: %s", name_.c_str(), sensor_type_name.c_str());
+  }
+
   // Validate topic names list: it must be a (normally non-empty) list of strings
   if ((topic_names.valid() == false) || (topic_names.getType() != XmlRpc::XmlRpcValue::TypeArray))
   {
@@ -68,7 +87,22 @@ void RangeSensorLayer::onInitialize()
       if ((topic_name.size() > 0) && (topic_name.at(topic_name.size() - 1) != '/'))
         topic_name += "/";
       topic_name += static_cast<std::string>(topic_names[i]);
-      range_subs_.push_back(nh.subscribe(topic_name, 100, &RangeSensorLayer::incomingRange, this));
+
+      if (input_sensor_type == VARIABLE)
+        processRangeMessageFunc_ = boost::bind(&RangeSensorLayer::processVariableRangeMsg, this, _1);
+      else if (input_sensor_type == FIXED)
+        processRangeMessageFunc_ = boost::bind(&RangeSensorLayer::processFixedRangeMsg, this, _1);
+      else if (input_sensor_type == ALL)
+        processRangeMessageFunc_ = boost::bind(&RangeSensorLayer::processRangeMsg, this, _1);
+      else
+      {
+        ROS_ERROR(
+            "%s: Invalid input sensor type: %s. Did you make a new type and forgot to choose the subscriber for it?",
+            name_.c_str(), sensor_type_name.c_str());
+      }
+
+      range_subs_.push_back(nh.subscribe(topic_name, 100, &RangeSensorLayer::bufferIncomingRangeMsg, this));
+
       ROS_INFO("RangeSensorLayer: subscribed to topic %s", range_subs_.back().getTopic().c_str());
     }
   }
@@ -134,27 +168,85 @@ void RangeSensorLayer::reconfigureCB(costmap_2d::GenericPluginConfig &config, ui
   }
 }
 
-void RangeSensorLayer::incomingRange(const sensor_msgs::RangeConstPtr& range)
+void RangeSensorLayer::bufferIncomingRangeMsg(const sensor_msgs::RangeConstPtr& range_message)
 {
-  double r = range->range;
-  bool clear_sensor_cone = false;
-  if (r < range->min_range)
-    return;
-  else if (r >= range->max_range && clear_on_max_reading_)
+  boost::mutex::scoped_lock lock(range_message_mutex_);
+  range_msgs_buffer_.push_back(*range_message);
+}
+
+void RangeSensorLayer::updateCostmap()
+{
+  std::list<sensor_msgs::Range> range_msgs_buffer_copy;
+
+  range_message_mutex_.lock();
+  range_msgs_buffer_copy = std::list<sensor_msgs::Range>(range_msgs_buffer_);
+  range_msgs_buffer_.clear();
+  range_message_mutex_.unlock();
+
+  for (std::list<sensor_msgs::Range>::iterator range_msgs_it = range_msgs_buffer_copy.begin();
+      range_msgs_it != range_msgs_buffer_copy.end(); range_msgs_it++)
   {
-    clear_sensor_cone = true;
-    r = range->max_range;
+    processRangeMessageFunc_(*range_msgs_it);
+  }
+}
+
+void RangeSensorLayer::processRangeMsg(sensor_msgs::Range& range_message)
+{
+  if (range_message.min_range == range_message.max_range)
+    processFixedRangeMsg(range_message);
+  else
+    processVariableRangeMsg(range_message);
+}
+
+void RangeSensorLayer::processFixedRangeMsg(sensor_msgs::Range& range_message)
+{
+  if (!isinf(range_message.range))
+  {
+    ROS_ERROR_THROTTLE(1.0,
+        "Fixed distance ranger (min_range == max_range) in frame %s sent invalid value. Only -Inf (== object detected) and Inf (== no object detected) are valid.",
+        range_message.header.frame_id.c_str());
+    return;
   }
 
-  max_angle_ = range->field_of_view/2;
+  bool clear_sensor_cone = false;
+
+  if (range_message.range > 0) //+inf
+  {
+    if (!clear_on_max_reading_)
+      return; //no clearing at all
+
+    clear_sensor_cone = true;
+  }
+
+  range_message.range = range_message.min_range;
+
+  updateCostmap(range_message, clear_sensor_cone);
+}
+
+void RangeSensorLayer::processVariableRangeMsg(sensor_msgs::Range& range_message)
+{
+  if (range_message.range < range_message.min_range || range_message.range > range_message.max_range)
+    return;
+
+  bool clear_sensor_cone = false;
+
+  if (range_message.range == range_message.max_range && clear_on_max_reading_)
+    clear_sensor_cone = true;
+
+  updateCostmap(range_message, clear_sensor_cone);
+}
+
+void RangeSensorLayer::updateCostmap(sensor_msgs::Range& range_message, bool clear_sensor_cone)
+{
+  max_angle_ = range_message.field_of_view/2;
 
   geometry_msgs::PointStamped in, out;
-  in.header.stamp = range->header.stamp;
-  in.header.frame_id = range->header.frame_id;
+  in.header.stamp = range_message.header.stamp;
+  in.header.frame_id = range_message.header.frame_id;
 
   if(!tf_->waitForTransform(global_frame_, in.header.frame_id,
         in.header.stamp, ros::Duration(0.1)) ) {
-     ROS_ERROR("Range sensor layer can't transform from %s to %s at %f",
+     ROS_ERROR_THROTTLE(1.0, "Range sensor layer can't transform from %s to %s at %f",
         global_frame_.c_str(), in.header.frame_id.c_str(),
         in.header.stamp.toSec());
      return;
@@ -164,7 +256,7 @@ void RangeSensorLayer::incomingRange(const sensor_msgs::RangeConstPtr& range)
 
   double ox = out.point.x, oy = out.point.y;
 
-  in.point.x = r;
+  in.point.x = range_message.range;
 
   tf_->transformPoint(global_frame_, in, out);
 
@@ -224,7 +316,7 @@ void RangeSensorLayer::incomingRange(const sensor_msgs::RangeConstPtr& range)
     for(unsigned int y=by0; y<=(unsigned int)by1; y++){
       double wx, wy;
       mapToWorld(x,y,wx,wy);
-      update_cell(ox, oy, theta, r, wx, wy, clear_sensor_cone);
+      update_cell(ox, oy, theta, range_message.range, wx, wy, clear_sensor_cone);
     }
   }
 
@@ -260,6 +352,8 @@ void RangeSensorLayer::updateBounds(double robot_x, double robot_y, double robot
 {
   if (layered_costmap_->isRolling())
     updateOrigin(robot_x - getSizeInMetersX() / 2, robot_y - getSizeInMetersY() / 2);
+
+  updateCostmap();
 
   *min_x = std::min(*min_x, min_x_);
   *min_y = std::min(*min_y, min_y_);


### PR DESCRIPTION
Adds buffering for incoming range messages
Adds support of fixed distance binary sensors
Changes managing of corner cases to adhere the range sensor message specification
Adds parameter to set input sensor type

Same as https://github.com/DLu/navigation_layers/pull/17 and https://github.com/DLu/navigation_layers/pull/16 for hydro
