### PR TITLE
Do not consider NO_INFORMATION as lethal obstacle

### DIFF
--- a/range_sensor_layer/src/range_sensor_layer.cpp
+++ b/range_sensor_layer/src/range_sensor_layer.cpp
@@ -398,7 +398,11 @@ void RangeSensorLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i
     {
       unsigned char prob = costmap_[it];
       unsigned char current;
-      if(prob>mark)
+      if(prob==costmap_2d::NO_INFORMATION){
+        it++;
+        continue;
+      }
+      else if(prob>mark)
         current = costmap_2d::LETHAL_OBSTACLE;
       else if(prob<clear)
         current = costmap_2d::FREE_SPACE;


### PR DESCRIPTION
This prevents the whole costmap to appear as an obstacle when using clear costmap recovery behaviors
