### PR TITLE
Add buffer clearing when calling deactivate() or activate().

### DIFF
--- a/range_sensor_layer/include/range_sensor_layer/range_sensor_layer.h
+++ b/range_sensor_layer/include/range_sensor_layer/range_sensor_layer.h
@@ -27,6 +27,8 @@ public:
                              double* max_y);
   virtual void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
   virtual void reset();
+  virtual void deactivate();
+  virtual void activate();
 
 private:
   void reconfigureCB(range_sensor_layer::RangeSensorLayerConfig &config, uint32_t level);

--- a/range_sensor_layer/src/range_sensor_layer.cpp
+++ b/range_sensor_layer/src/range_sensor_layer.cpp
@@ -432,4 +432,14 @@ void RangeSensorLayer::reset()
   activate();
 }
 
+void RangeSensorLayer::deactivate()
+{
+  range_msgs_buffer_.clear();
+}
+
+void RangeSensorLayer::activate()
+{
+  range_msgs_buffer_.clear();
+}
+
 } // end namespace


### PR DESCRIPTION
There is issue when I set shutdown_costmaps parameters within move_base node to true.
It said that "Range sensor layer can't transform" which is similar to [this](http://answers.ros.org/question/209425/range_sensor_layer-cant-transform-from-map-to-us1/)
You can see that the time that it requested for transform was too old, so it can't find the tf for that message.

After I explore move_base code, move_base deactivate all layers when shutdown_costmaps is true and move_base is inactive. So I realize that we need to clear buffer when layers is deactivate and re-activate.