### PR TITLE
range sensor layer: Remove parameter max_angle

### DIFF
--- a/range_sensor_layer/cfg/RangeSensorLayer.cfg
+++ b/range_sensor_layer/cfg/RangeSensorLayer.cfg
@@ -7,7 +7,6 @@ gen = ParameterGenerator()
 
 gen.add('enabled',               bool_t, 0, 'Whether to apply this plugin or not', True)
 gen.add('phi',                 double_t, 0, 'Phi value', 1.2)
-gen.add('max_angle',           double_t, 0, 'Maximum angle (radians)', 12.5*3.14/180, 0, 3.1415)
 gen.add('inflate_cone',        double_t, 0, 'Inflate the triangular area covered by the sensor (percentage)', 1, 0, 1)
 gen.add('no_readings_timeout', double_t, 0, 'No Readings Timeout', 0.0, 0.0)
 gen.add('clear_threshold',     double_t, 0, 'Probability below which cells are marked as free', 0.2, 0.0, 1.0)

--- a/range_sensor_layer/src/range_sensor_layer.cpp
+++ b/range_sensor_layer/src/range_sensor_layer.cpp
@@ -153,7 +153,6 @@ double RangeSensorLayer::sensor_model(double r, double phi, double theta)
 void RangeSensorLayer::reconfigureCB(range_sensor_layer::RangeSensorLayerConfig &config, uint32_t level)
 {
   phi_v_ = config.phi;
-  max_angle_ = config.max_angle;
   inflate_cone_ = config.inflate_cone;
   no_readings_timeout_ = config.no_readings_timeout;
   clear_threshold_ = config.clear_threshold;


### PR DESCRIPTION
Any value set for max_angle gets overwritten in updateCostmap() so the
parameter can safely be removed.